### PR TITLE
Fix WebSocket Docker build and add health check

### DIFF
--- a/Dockerfile.websocket
+++ b/Dockerfile.websocket
@@ -1,15 +1,11 @@
 # Dockerfile for WebSocket server
 FROM node:20-alpine
 
-# Install PM2 globally for process management
-RUN npm install -g pm2
-
 WORKDIR /app
 
 # Copy WebSocket server files
 COPY websocket-server.js ./
 COPY transcription-worker.js ./
-COPY ecosystem.config.js ./
 COPY package.json package-lock.json* ./
 
 # Install only production dependencies

--- a/websocket-server.js
+++ b/websocket-server.js
@@ -24,7 +24,14 @@ const server = http.createServer((req, res) => {
     res.end()
     return
   }
-  
+
+  // Health check endpoint for Docker/Cloud Run
+  if (req.method === 'GET' && req.url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ status: 'healthy', timestamp: Date.now() }))
+    return
+  }
+
   if (req.method === 'POST' && req.url === '/broadcast') {
     let body = ''
     req.on('data', chunk => {


### PR DESCRIPTION
- Remove ecosystem.config.js from Dockerfile (was in .dockerignore)
- Remove PM2 as it's not needed in containerized deployment
- Add /health endpoint to websocket-server.js for Cloud Run health checks
- Simplify Dockerfile.websocket for container environment

🤖 Generated with [Claude Code](https://claude.ai/code)