### PR TITLE
Fix toLocaleString errors on undefined values

### DIFF
--- a/src/app/instructor/course/[id]/analytics/page.tsx
+++ b/src/app/instructor/course/[id]/analytics/page.tsx
@@ -108,7 +108,7 @@ export default function CourseAnalyticsPageClean() {
             <TrendingUp className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">${course.revenue.total.toLocaleString()}</div>
+            <div className="text-2xl font-bold">${(course.revenue?.total || 0).toLocaleString()}</div>
             <p className="text-xs text-muted-foreground">${course.revenue.thisMonth} this month</p>
           </CardContent>
         </Card>

--- a/src/app/instructor/course/[id]/video/[videoId]/page.tsx
+++ b/src/app/instructor/course/[id]/video/[videoId]/page.tsx
@@ -374,7 +374,7 @@ export default function InstructorVideoPage() {
                   <div className="flex items-center gap-4 mt-2 text-sm text-muted-foreground">
                     <span className="flex items-center gap-1">
                       <Eye className="h-4 w-4" />
-                      {lesson.views.toLocaleString()} views
+                      {(lesson.views || 0).toLocaleString()} views
                     </span>
                     <span className="flex items-center gap-1">
                       <Clock className="h-4 w-4" />

--- a/src/app/instructor/courses/page.tsx
+++ b/src/app/instructor/courses/page.tsx
@@ -333,7 +333,7 @@ export default function TeachCoursesPage() {
                 </div>
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-muted-foreground">Students</span>
-                  <span className="font-medium">{course.students.toLocaleString()}</span>
+                  <span className="font-medium">{(course.students || 0).toLocaleString()}</span>
                 </div>
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-muted-foreground">Completion</span>
@@ -342,7 +342,7 @@ export default function TeachCoursesPage() {
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-muted-foreground">Revenue</span>
                   <span className="font-medium text-green-600">
-                    ${course.revenue.toLocaleString()}
+                    ${(course.revenue || 0).toLocaleString()}
                   </span>
                 </div>
                 

--- a/src/app/instructor/lesson/[id]/analytics/page.tsx
+++ b/src/app/instructor/lesson/[id]/analytics/page.tsx
@@ -144,7 +144,7 @@ export default function LessonAnalyticsPage() {
             <Eye className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{lesson.totalViews.toLocaleString()}</div>
+            <div className="text-2xl font-bold">{(lesson.totalViews || 0).toLocaleString()}</div>
             <p className="text-xs text-muted-foreground">All time</p>
           </CardContent>
         </Card>
@@ -155,7 +155,7 @@ export default function LessonAnalyticsPage() {
             <UserCheck className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{lesson.authenticatedUsers.toLocaleString()}</div>
+            <div className="text-2xl font-bold">{(lesson.authenticatedUsers || 0).toLocaleString()}</div>
             <p className="text-xs text-muted-foreground">
               {Math.round((lesson.authenticatedUsers / lesson.totalStudents) * 100)}% of viewers
             </p>

--- a/src/app/instructor/lessons/page.tsx
+++ b/src/app/instructor/lessons/page.tsx
@@ -287,7 +287,7 @@ export default function TeachLessonsPage() {
                 <div className="grid grid-cols-3 gap-2 text-sm">
                   <div className="flex items-center gap-1">
                     <Eye className="h-3 w-3 text-muted-foreground" />
-                    <span>{lesson.views.toLocaleString()}</span>
+                    <span>{(lesson.views || 0).toLocaleString()}</span>
                   </div>
                   <div className="flex items-center gap-1">
                     <Sparkles className="h-3 w-3 text-muted-foreground" />

--- a/src/app/instructor/page.tsx
+++ b/src/app/instructor/page.tsx
@@ -169,7 +169,7 @@ export default function InstructorDashboard() {
             <DollarSign className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">${periodTotals.revenue.toLocaleString()}</div>
+            <div className="text-2xl font-bold">${(periodTotals.revenue || 0).toLocaleString()}</div>
             <div className="flex items-center text-xs mt-2">
               {changes.revenue > 0 ? (
                 <>
@@ -193,7 +193,7 @@ export default function InstructorDashboard() {
             <Users className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{periodTotals.students.toLocaleString()}</div>
+            <div className="text-2xl font-bold">{(periodTotals.students || 0).toLocaleString()}</div>
             <div className="flex items-center text-xs mt-2">
               {changes.students > 0 ? (
                 <>

--- a/src/components/lesson/RelatedLessonsCarousel.tsx
+++ b/src/components/lesson/RelatedLessonsCarousel.tsx
@@ -171,7 +171,7 @@ export function RelatedLessonsCarousel({
                   <div className="flex items-center gap-4 text-xs text-muted-foreground">
                     <span className="flex items-center gap-1">
                       <Eye className="h-3 w-3" />
-                      {lesson.views.toLocaleString()}
+                      {(lesson.views || 0).toLocaleString()}
                     </span>
                     <span className="flex items-center gap-1">
                       <Sparkles className="h-3 w-3" />


### PR DESCRIPTION
- Add null checks for all numeric values before calling toLocaleString()
- Prevents 'Cannot read properties of undefined' errors in production
- Default to 0 when values are undefined or null

🤖 Generated with [Claude Code](https://claude.ai/code)