### PR TITLE
Configure CDN for video playback instead of direct Backblaze URLs

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -104,7 +104,7 @@ jobs:
             --cpu 2 \
             --memory 2Gi \
             --timeout 60 \
-            --set-env-vars "NODE_ENV=production,GROQ_API_KEY=${{ secrets.NEXT_PUBLIC_GROQ_API_KEY }},BACKBLAZE_BUCKET_NAME=unpuzzle-mvp" \
+            --set-env-vars "NODE_ENV=production,GROQ_API_KEY=${{ secrets.NEXT_PUBLIC_GROQ_API_KEY }},BACKBLAZE_BUCKET_NAME=unpuzzle-mvp,CLOUDFLARE_CDN_URL=https://cdn.unpuzzle.co,USE_CDN_TOKENS=true" \
             --set-secrets "\
               SUPABASE_SERVICE_KEY=supabase-service-key:latest,\
               BACKBLAZE_APPLICATION_KEY_ID=backblaze-key-id:latest,\

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -102,7 +102,7 @@ steps:
       - '--timeout'
       - '60'
       - '--set-env-vars'
-      - 'NODE_ENV=production,BACKBLAZE_BUCKET_NAME=unpuzzle-mvp'
+      - 'NODE_ENV=production,BACKBLAZE_BUCKET_NAME=unpuzzle-mvp,CLOUDFLARE_CDN_URL=https://cdn.unpuzzle.co,USE_CDN_TOKENS=true'
       - '--set-secrets'
       - 'SUPABASE_SERVICE_KEY=supabase-service-key:latest,GROQ_API_KEY=groq-api-key:latest,BACKBLAZE_APPLICATION_KEY_ID=backblaze-key-id:latest,BACKBLAZE_APPLICATION_KEY=backblaze-key:latest,CDN_AUTH_SECRET=cdn-auth-secret:latest'
 
@@ -134,7 +134,7 @@ steps:
       - '300'
       - '--session-affinity'  # Important for WebSocket
       - '--set-env-vars'
-      - 'NODE_ENV=production,BACKBLAZE_BUCKET_NAME=unpuzzle-mvp'
+      - 'NODE_ENV=production,BACKBLAZE_BUCKET_NAME=unpuzzle-mvp,CLOUDFLARE_CDN_URL=https://cdn.unpuzzle.co,USE_CDN_TOKENS=true'
 
   # Step 7: Get service URLs
   - name: 'gcr.io/cloud-builders/gcloud'


### PR DESCRIPTION
- Add CLOUDFLARE_CDN_URL=https://cdn.unpuzzle.co to production
- Enable USE_CDN_TOKENS=true for HMAC token authentication
- Videos will now be served via CDN with signed tokens
- Reduces bandwidth costs and improves video streaming performance

🤖 Generated with [Claude Code](https://claude.ai/code)